### PR TITLE
# Add CRUD Operations to Categories ViewSet

### DIFF
--- a/madinastockapi/views/categories.py
+++ b/madinastockapi/views/categories.py
@@ -33,3 +33,38 @@ class CategoryView(ViewSet):
         categories = Category.objects.all()
         serializer = CategorySerializer(categories, many=True)
         return Response(serializer.data)
+
+    def create(self, request):
+        """
+        Create a new category
+        POST /api/categories/
+        """
+        category = Category.objects.create(
+            user_id=request.data["user_id"],
+            name=request.data["name"],
+            description=request.data.get("description", "")
+        )
+        serializer = CategorySerializer(category)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def update(self, request, pk):
+        """
+        Update an existing category
+        PUT /api/categories/{id}/
+        """
+        category = Category.objects.get(pk=pk)
+        category.user_id = request.data["user_id"]
+        category.name = request.data["name"]
+        category.description = request.data.get("description", "")
+        category.save()
+        serializer = CategorySerializer(category)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def destroy(self, request, pk):
+        """
+        Delete a category
+        DELETE /api/categories/{id}/
+        """
+        category = Category.objects.get(pk=pk)
+        category.delete()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
# Add CRUD Operations to Categories ViewSet

## Description

This PR adds full CRUD (Create, Read, Update, Delete) functionality to the `CategoryViewSet` in the categories API. Previously, the viewset only supported listing categories. Now it supports:

- **CREATE**: POST endpoint to create new categories with user_id, name, and optional description
- **UPDATE**: PUT endpoint to update existing categories by ID
- **DELETE**: DELETE endpoint to remove categories by ID

The implementation includes proper HTTP status codes (201 for creation, 200 for updates, 204 for deletion) and uses the existing `CategorySerializer` for consistent data formatting.

## Motivation and Context

This change was required to provide complete category management functionality through the API. Previously, users could only retrieve/list categories but couldn't create, modify, or delete them through the API endpoints. This enhancement enables full category lifecycle management for the stock management system.

## How Can This Be Tested?

### Create Category (POST)
```bash
curl -X POST http://localhost:8000/api/categories/ \
  -H "Content-Type: application/json" \
  -d '{
    "user_id": 1,
    "name": "Electronics",
    "description": "Electronic items and gadgets"
  }'
```

### Update Category (PUT)
```bash
curl -X PUT http://localhost:8000/api/categories/1/ \
  -H "Content-Type: application/json" \
  -d '{
    "user_id": 1,
    "name": "Updated Electronics",
    "description": "Updated description"
  }'
```

### Delete Category (DELETE)
```bash
curl -X DELETE http://localhost:8000/api/categories/1/
```

### List Categories (GET) - existing functionality
```bash
curl -X GET http://localhost:8000/api/categories/
```


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)